### PR TITLE
WIP: Bruk dekoratoren som web-component

### DIFF
--- a/inngar-intern/app/components/Decorator.tsx
+++ b/inngar-intern/app/components/Decorator.tsx
@@ -1,7 +1,5 @@
-import { useEffect, useRef } from "react"
 import { EnvType, getEnv } from "~/util/envUtil"
 import { ClientOnlyChild } from "~/util/remoteUtil"
-import { useDecorateNavspa } from "~/util/useNAVSPA.tsx"
 
 type OnFnrChanged = (fnr?: string | null | undefined) => void
 
@@ -16,42 +14,25 @@ const InternarbeidsflateDecorator = ({
 }: {
     onFnrChanged: OnFnrChanged
 }) => {
-    const rootMountRef = useRef<HTMLDivElement>(null)
-    const mountFunction = useDecorateNavspa()
-    const hasMountedRef = useRef(false)
+    return (
+        <internarbeidsflate-decorator
+            app-name="Arbeidsrettet oppfølging"
+            environment={env.type == EnvType.prod ? "prod" : "q2"}
+            url-format={env.ingressType === "ansatt" ? "ANSATT" : "NAV_NO"}
+            show-enheter={false}
+            show-search-area={true}
+            fetch-active-enhet-on-mount={false}
+            fetch-active-user-on-mount
+            // onEnhetChanged={() => {}}
+            onFnrChanged={onFnrChanged}
+            show-hotkeys={false}
+            proxy={"/api/modiacontextholder"}
+        >
+            <DecoratorPlaceholder />
+        </internarbeidsflate-decorator>
+    )
 
-    useEffect(() => {
-        // Only mount once when NAVSPA becomes available
-        if (rootMountRef.current && mountFunction && !hasMountedRef.current) {
-            hasMountedRef.current = true
-            try {
-                mountFunction(rootMountRef.current, {
-                    fetchActiveUserOnMount: true,
-                    fetchActiveEnhetOnMount: false,
-                    onEnhetChanged: () => {},
-                    onFnrChanged: onFnrChanged,
-                    showSearchArea: true,
-                    showEnheter: false,
-                    appName: "Arbeidsrettet oppfølging",
-                    environment: env.type == EnvType.prod ? "prod" : "q2",
-                    urlFormat:
-                        env.ingressType === "ansatt" ? "ANSATT" : "NAV_NO",
-                    showHotkeys: false,
-                    proxy: "/api/modiacontextholder",
-                })
-            } catch (e) {
-                console.error("Failed to mount NAVSPA decorator:", e)
-                hasMountedRef.current = false // Allow retry on error
-            }
-        }
-    }, [mountFunction, onFnrChanged])
-
-    // Show placeholder while waiting for NAVSPA to load
-    if (!mountFunction) {
-        return <DecoratorPlaceholder />
-    }
-
-    return <div className="bg-gray-900 min-h-[48px]" ref={rootMountRef}></div>
+    // return <div className="bg-gray-900 min-h-[48px]" ref={rootMountRef}></div>
 }
 
 const Decorator = ({ onFnrChanged }: { onFnrChanged: OnFnrChanged }) => {

--- a/inngar-intern/app/components/Visittkort.tsx
+++ b/inngar-intern/app/components/Visittkort.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react"
 import { ClientOnlyChild } from "~/util/remoteUtil"
 import { type FnrState } from "~/root"
 import { getOversiktenLink } from "~/config.client.ts"
@@ -60,10 +59,6 @@ const Visittkort = ({
     fnrState: FnrState
     navKontor: string | null | undefined
 }) => {
-    useEffect(() => {
-        console.log("On mount Visittkort")
-    }, [])
-
     if (fnrState.loading || !fnrState.fnr) return null
     return (
         <div className="bg-ax-bg-default min-h-[76.8px]">

--- a/inngar-intern/app/hooks/useFeatureToggle.ts
+++ b/inngar-intern/app/hooks/useFeatureToggle.ts
@@ -8,7 +8,6 @@ export function useFeatureToggle(featureName: FeatureToggles): boolean {
     const [enabled, setEnabled] = useState(false)
 
     useEffect(() => {
-        logger.info("Henter toggle...")
         fetch(`/veilarbaktivitet/api/feature?feature=${featureName}`)
             .then((res) => {
                 if (res.ok) {

--- a/inngar-intern/app/mock/handlers.ts
+++ b/inngar-intern/app/mock/handlers.ts
@@ -17,6 +17,7 @@ const veilarbveileder = `http://veilarbveileder.obo`
 const aoOppfolgingskontor = `http://ao-oppfolgingskontor.dab`
 const oboUnleash = `http://obo-unleash.obo`
 const veilarbaktivitet = `http://veilarbaktivitet.dab`
+const veilarbvedtakstotte = `http://veilarbvedtaksstotte.obo`
 
 const getAktivBrukerMock = () => {
     const over18Mocking = mockSettings.over18
@@ -224,8 +225,7 @@ export const handlers = [
     }),
     http.get(`${oboUnleash}/api/feature`, () => {
         return HttpResponse.json({
-            "veilarbvisittkortfs.vis-ny-inngang-til-arbeidsrettet-oppfolging":
-                true,
+            "veilarbvisittkortfs.vis-ny-inngang-til-arbeidsrettet-oppfolging": true,
         })
     }),
     http.get(
@@ -239,6 +239,12 @@ export const handlers = [
             }
 
             return HttpResponse.json(features)
+        },
+    ),
+    http.post(
+        `${veilarbvedtakstotte}/veilarbvedtaksstotte/api/hent-gjeldende-14a-vedtak`,
+        () => {
+            return new HttpResponse()
         },
     ),
 ]

--- a/inngar-intern/app/root.tsx
+++ b/inngar-intern/app/root.tsx
@@ -7,7 +7,7 @@ import {
     ScrollRestoration,
     useFetcher,
     useLoaderData,
-    useParams
+    useParams,
 } from "react-router"
 import "@navikt/ds-css"
 
@@ -94,7 +94,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
                 <Links />
                 <script src={jsUrl} type="module" />
                 <script
-                    src={`https://cdn.nav.no/personoversikt/internarbeidsflate-decorator-v3/${isProd ? "prod" : "dev"}/latest/dist/bundle.js`}
+                    src={`https://cdn.nav.no/personoversikt/internarbeidsflate-decorator-v3/${isProd ? "prod" : "dev"}/latest/dist/internarbeidsflate-decorator.wc.js`}
                     defer
                 />
                 <link
@@ -105,6 +105,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
             <body>
                 <Decorator
                     onFnrChanged={(fnr) => {
+                        console.log("onFnrChanged", fnr)
                         redirectToChangedUser(fnr)
                     }}
                 />

--- a/inngar-intern/global.d.ts
+++ b/inngar-intern/global.d.ts
@@ -1,0 +1,32 @@
+interface DecoratorElementAttributes {
+    "app-name"?: string
+    environment?: string
+    "url-format"?: string
+    fnr?: string
+    enhet?: string
+    "fnr-sync-mode"?: string
+    "enhet-sync-mode"?: string
+    "show-enheter"?: string
+    "show-search-area"?: string
+    "show-hotkeys"?: string
+    "enable-hotkeys"?: string
+    "fetch-active-enhet-on-mount"?: string
+    "fetch-active-user-on-mount"?: string
+    markup?: string
+    hotkeys?: string
+    proxy?: string
+    "websocket-url"?: string
+    "access-token"?: string
+    "include-credentials"?: string
+    "user-key"?: string
+}
+
+declare namespace React {
+    namespace JSX {
+        interface IntrinsicElements {
+            "internarbeidsflate-decorator": React.HTMLAttributes<HTMLElement> &
+                React.RefAttributes<HTMLElement> &
+                DecoratorElementAttributes
+        }
+    }
+}


### PR DESCRIPTION
Bytt til å bruke dekoratoren som web-component istedetfor en hacky løsning for å rendre ca sånn som NAVSPA gjør det

Disse tingene gjenstår
- [ ] Få onFnrChanged til å funke, nå skjer ingenting når man skifter fnr 